### PR TITLE
Added BOWR tim type to `07-tim_type.sql`

### DIFF
--- a/db-scripts/pgsql/static-data/sql/07-tim_type.sql
+++ b/db-scripts/pgsql/static-data/sql/07-tim_type.sql
@@ -11,6 +11,7 @@ INSERT INTO tim_type (type,description,tim_type_id) VALUES (E'I',E'Incident',3);
 INSERT INTO tim_type (type,description,tim_type_id) VALUES (E'RW',E'Road Construction',4);
 INSERT INTO tim_type (type,description,tim_type_id) VALUES (E'CC',E'Chain Controls',5);
 INSERT INTO tim_type (type,description,tim_type_id) VALUES (E'P',E'Parking',6);
+INSERT INTO tim_type (type,description,tim_type_id) VALUES (E'BOWR',E'Blow Over Weight Restriction',7);
 
 COMMIT;
 


### PR DESCRIPTION
## Problem
The "BOWR" tim type was not included in the static-data SQL script for populating the `tim_type` table. This is required for the creation of 'Blow Over Weight Restriction' TIMs.

## Solution
The `07-tim_type.sql` file has been updated to include the "BOWR" tim type

## Testing
Adding the "BOWR" TIM type to the `tim_type` table has been verified to make the creation of BOWR TIMs possible in WYDOT's environment.

## Relevant Issue
No relevant GitHub issue