### PR TITLE
Fixed `MismatchedInputException` by Explicitly Returning JSON in `GetItisCodesForDataFrameId` Endpoint

### DIFF
--- a/cv-data-controller/src/main/java/com/trihydro/cvdatacontroller/controller/DataFrameController.java
+++ b/cv-data-controller/src/main/java/com/trihydro/cvdatacontroller/controller/DataFrameController.java
@@ -45,7 +45,7 @@ public class DataFrameController extends BaseController {
 		sqlNullHandler = _sqlNullHandler;
 	}
 
-	@RequestMapping(method = RequestMethod.GET, value = "/itis-for-data-frame/{dataFrameId}")
+	@RequestMapping(method = RequestMethod.GET, produces = "application/json", value = "/itis-for-data-frame/{dataFrameId}")
 	public ResponseEntity<String[]> GetItisCodesForDataFrameId(@PathVariable Integer dataFrameId) {
 		Connection connection = null;
 		Statement statement = null;


### PR DESCRIPTION
## Problem
When retrieving ITIS codes associated with a data frame while re-submitting a TIM, the DataFrameController can return XML instead of JSON. This discrepancy leads to a MismatchedInputException error, as indicated by the stack trace, which shows that an XmlDeserializer is mistakenly used to parse the response.

Furthermore, accessing the endpoint via a browser confirms that the response content type is XML.

## Solution
The DataFrameController's GetItisCodesForDataFrameId endpoint has been updated to explicitly return responses in JSON format.

## Testing
After applying the fix, accessing the endpoint through a browser now displays the response in JSON format, as expected.

## Relevant Issues
Closes #25 

## Next Steps
To prevent similar MismatchedInputException errors across the system, all endpoints expected to return JSON should be reviewed and updated to ensure they explicitly specify JSON as the response format.