### PR TITLE
Use a Single MongoClient Instance

### DIFF
--- a/ode-mongo-logger/src/main/java/com/trihydro/mongologger/app/loggers/MongoLogger.java
+++ b/ode-mongo-logger/src/main/java/com/trihydro/mongologger/app/loggers/MongoLogger.java
@@ -57,7 +57,7 @@ public class MongoLogger {
     }
 
     public void logMultipleToCollection(String[] records, String collectionName) {
-        ArrayList<Document> docs = new ArrayList<Document>();
+        ArrayList<Document> docs = new ArrayList<>();
 
         for (String rec : records) {
             docs.add(Document.parse(rec));

--- a/ode-mongo-logger/src/main/java/com/trihydro/mongologger/app/loggers/MongoLogger.java
+++ b/ode-mongo-logger/src/main/java/com/trihydro/mongologger/app/loggers/MongoLogger.java
@@ -14,6 +14,7 @@ import com.trihydro.library.helpers.EmailHelper;
 import com.trihydro.library.helpers.Utility;
 import com.trihydro.mongologger.app.MongoLoggerConfiguration;
 
+import java.util.List;
 import org.bson.Document;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -22,10 +23,7 @@ import org.springframework.stereotype.Component;
 public class MongoLogger {
 
     private String serverAddress;
-    private String username;
-    private String password;
     private String databaseName;
-    private String authDatabaseName;
     private MongoCredential credential;
     private Utility utility;
     private EmailHelper emailHelper;
@@ -35,10 +33,10 @@ public class MongoLogger {
     @Autowired
     public void InjectDependencies(MongoLoggerConfiguration _config, Utility _utility, EmailHelper _emailHelper) {
         config = _config;
-        username = config.getMongoUsername(); // the user name
+        String username = config.getMongoUsername(); // the user name
         databaseName = config.getMongoDatabase(); // the name of the database to deposit records into
-        authDatabaseName = config.getMongoAuthDatabase(); // the name of the database in which the user is defined
-        password = config.getMongoPassword(); // the password as a character array
+        String authDatabaseName = config.getMongoAuthDatabase(); // the name of the database in which the user is defined
+        String password = config.getMongoPassword(); // the password as a character array
         serverAddress = config.getMongoHost();
         credential = MongoCredential.createCredential(username, authDatabaseName, password.toCharArray());
         utility = _utility;
@@ -48,7 +46,7 @@ public class MongoLogger {
 
     private void configureMongoClient() {
         _mongoClient =
-            MongoClients.create(MongoClientSettings.builder().applyToClusterSettings(builder -> builder.hosts(Arrays.asList(new ServerAddress(serverAddress, 27017)))).credential(credential).build());
+            MongoClients.create(MongoClientSettings.builder().applyToClusterSettings(builder -> builder.hosts(List.of(new ServerAddress(serverAddress, 27017)))).credential(credential).build());
     }
 
     public void logTim(String[] timRecord) {
@@ -70,7 +68,7 @@ public class MongoLogger {
             docs.add(Document.parse(rec));
         }
 
-        if (docs.size() > 0) {
+        if (!docs.isEmpty()) {
             try {
                 MongoDatabase database = _mongoClient.getDatabase(databaseName);
                 MongoCollection<Document> collection = database.getCollection(collectionName);

--- a/ode-mongo-logger/src/main/java/com/trihydro/mongologger/app/loggers/MongoLogger.java
+++ b/ode-mongo-logger/src/main/java/com/trihydro/mongologger/app/loggers/MongoLogger.java
@@ -84,6 +84,7 @@ public class MongoLogger {
                 try {
                     emailHelper.SendEmail(config.getAlertAddresses(), "MongoLogger Failed to Connect to MongoDB", body);
                 } catch (Exception e) {
+                    utility.logWithDate("Error sending email: " + e.getMessage());
                     e.printStackTrace();
                 }
             }

--- a/ode-mongo-logger/src/main/java/com/trihydro/mongologger/app/loggers/MongoLogger.java
+++ b/ode-mongo-logger/src/main/java/com/trihydro/mongologger/app/loggers/MongoLogger.java
@@ -44,9 +44,12 @@ public class MongoLogger {
         configureMongoClient();
     }
 
-    private void configureMongoClient() {
-        _mongoClient =
-            MongoClients.create(MongoClientSettings.builder().applyToClusterSettings(builder -> builder.hosts(List.of(new ServerAddress(serverAddress, 27017)))).credential(credential).build());
+    private MongoClient configureMongoClient() {
+        var hosts = List.of(new ServerAddress(serverAddress, 27017));
+        var settings = MongoClientSettings.builder()
+                .applyToClusterSettings(builder -> builder.hosts(hosts)).credential(credential)
+                .build();
+        return MongoClients.create(settings);
     }
 
     public void logTim(String[] timRecord) {

--- a/ode-mongo-logger/src/main/java/com/trihydro/mongologger/app/loggers/MongoLogger.java
+++ b/ode-mongo-logger/src/main/java/com/trihydro/mongologger/app/loggers/MongoLogger.java
@@ -46,11 +46,9 @@ public class MongoLogger {
         configureMongoClient();
     }
 
-    private void configureMongoClient(){
-        _mongoClient = MongoClients.create(MongoClientSettings.builder()
-            .applyToClusterSettings(
-                builder -> builder.hosts(Arrays.asList(new ServerAddress(serverAddress, 27017))))
-            .credential(credential).build());
+    private void configureMongoClient() {
+        _mongoClient =
+            MongoClients.create(MongoClientSettings.builder().applyToClusterSettings(builder -> builder.hosts(Arrays.asList(new ServerAddress(serverAddress, 27017)))).credential(credential).build());
     }
 
     public void logTim(String[] timRecord) {


### PR DESCRIPTION
## Problem
The code was creating multiple MongoClient instances, which can lead to inefficient resource usage and connection management issues.

## Solution
Refactored to use a single MongoClient instance as recommended in the [MongoDB Java Driver documentation](https://mongodb.github.io/mongo-java-driver/3.4/driver-async/tutorials/connect-to-mongodb/).

## Testing
- Compilation verified
- Solution was spun up locally and the tim_logger-mongo service started successfully. After creating a TIM, the srevice consumed from the Kafka topic without reporting any errors:
![image](https://github.com/user-attachments/assets/c8d46003-6509-4e94-8381-ab3627188765)
    - The mongo service also reported a connection at this time.
