### PR TITLE
Improve Handling of Unique Constraint Errors in TimRsuService

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -271,6 +271,7 @@ services:
       MAIL_HOST: ${MAIL_HOST}
       MAIL_PORT: ${MAIL_PORT}
       ENV: ${DBCONSUMER_ENV}
+      LOGGING_LEVEL_COM_TRIHYDRO: ${LOGGING_LEVEL_COM_TRIHYDRO}
     logging:
       options:
         max-size: "20m"

--- a/local-deployment/docker-compose.yml
+++ b/local-deployment/docker-compose.yml
@@ -344,6 +344,7 @@ services:
       MAIL_HOST: 172.0.0.1
       MAIL_PORT: 123
       ENV: local
+      LOGGING_LEVEL_COM_TRIHYDRO: ${LOGGING_LEVEL_COM_TRIHYDRO}
     logging:
       options:
         max-size: "20m"

--- a/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
+++ b/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
@@ -12,6 +12,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+/**
+ * Service class for handling TIM RSU operations.
+ */
 @Component
 @Slf4j
 public class TimRsuService {
@@ -19,6 +22,13 @@ public class TimRsuService {
     private final TimDbTables timDbTables;
     private final SQLNullHandler sqlNullHandler;
 
+    /**
+     * Constructor for TimRsuService.
+     *
+     * @param dbInteractions the database interactions helper
+     * @param timDbTables the TIM database tables helper
+     * @param sqlNullHandler the SQL null handler
+     */
     @Autowired
     public TimRsuService(DbInteractions dbInteractions, TimDbTables timDbTables, SQLNullHandler sqlNullHandler) {
         this.dbInteractions = dbInteractions;
@@ -26,6 +36,14 @@ public class TimRsuService {
         this.sqlNullHandler = sqlNullHandler;
     }
 
+    /**
+     * Adds a TIM RSU record to the database.
+     *
+     * @param timId the TIM ID
+     * @param rsuId the RSU ID
+     * @param rsuIndex the RSU index
+     * @return the ID of the inserted TIM RSU record, 0 if a duplicate record is detected, or -1 if an error occurs
+     */
     public Long AddTimRsu(Long timId, Integer rsuId, Integer rsuIndex) {
         String insertQueryStatement = timDbTables.buildInsertQueryStatement("tim_rsu", timDbTables.getTimRsuTable());
 
@@ -51,7 +69,7 @@ public class TimRsuService {
 
             // Log the exception if it's not a unique constraint violation
             log.error("SQL Exception while adding TIM RSU: {}", e.getMessage(), e);
-            return 0L;
+            return -1L;
         }
     }
 }

--- a/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
+++ b/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
@@ -30,25 +30,25 @@ public class TimRsuService extends BaseService {
 
         try {
             connection = dbInteractions.getConnectionPool();
-            String insertQueryStatement = timDbTables.buildInsertQueryStatement("tim_rsu",
-                    timDbTables.getTimRsuTable());
-            preparedStatement = connection.prepareStatement(insertQueryStatement, new String[] { "tim_rsu_id" });
+            String insertQueryStatement = timDbTables.buildInsertQueryStatement("tim_rsu", timDbTables.getTimRsuTable());
+            preparedStatement = connection.prepareStatement(insertQueryStatement, new String[] {"tim_rsu_id"});
             int fieldNum = 1;
 
             for (String col : timDbTables.getTimRsuTable()) {
-                if (col.equals("TIM_ID"))
+                if (col.equals("TIM_ID")) {
                     sqlNullHandler.setLongOrNull(preparedStatement, fieldNum, timId);
-                else if (col.equals("RSU_ID"))
+                } else if (col.equals("RSU_ID")) {
                     sqlNullHandler.setIntegerOrNull(preparedStatement, fieldNum, rsuId);
-                else if (col.equals("RSU_INDEX"))
+                } else if (col.equals("RSU_INDEX")) {
                     sqlNullHandler.setIntegerOrNull(preparedStatement, fieldNum, rsuIndex);
+                }
                 fieldNum++;
             }
             Long timRsuId = dbInteractions.executeAndLog(preparedStatement, "tim rsu");
             return timRsuId;
         } catch (SQLException e) {
             // java.sql.SQLIntegrityConstraintViolationException: ORA-00001: unique constraint (CVCOMMS.TIM_RSU_U) violated 
-            if(!(e instanceof SQLIntegrityConstraintViolationException)) {
+            if (!(e instanceof SQLIntegrityConstraintViolationException)) {
                 e.printStackTrace();
             }
 
@@ -56,11 +56,13 @@ public class TimRsuService extends BaseService {
         } finally {
             try {
                 // close prepared statement
-                if (preparedStatement != null)
+                if (preparedStatement != null) {
                     preparedStatement.close();
+                }
                 // return connection back to pool
-                if (connection != null)
+                if (connection != null) {
                     connection.close();
+                }
             } catch (SQLException e) {
                 e.printStackTrace();
             }

--- a/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
+++ b/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
@@ -15,20 +15,19 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class TimRsuService extends BaseService {
-
-    private TimDbTables timDbTables;
-    private SQLNullHandler sqlNullHandler;
+    private final TimDbTables timDbTables;
+    private final SQLNullHandler sqlNullHandler;
 
     @Autowired
-    public void InjectDependencies(TimDbTables _timDbTables, SQLNullHandler _sqlNullHandler) {
-        timDbTables = _timDbTables;
-        sqlNullHandler = _sqlNullHandler;
+    public TimRsuService(TimDbTables timDbTables, SQLNullHandler sqlNullHandler) {
+        this.timDbTables = timDbTables;
+        this.sqlNullHandler = sqlNullHandler;
     }
 
     public Long AddTimRsu(Long timId, Integer rsuId, Integer rsuIndex) {
         String insertQueryStatement = timDbTables.buildInsertQueryStatement("tim_rsu", timDbTables.getTimRsuTable());
 
-        try(Connection connection = dbInteractions.getConnectionPool(); PreparedStatement preparedStatement = connection.prepareStatement(insertQueryStatement, new String[] {"tim_rsu_id"})) {
+        try (Connection connection = dbInteractions.getConnectionPool(); PreparedStatement preparedStatement = connection.prepareStatement(insertQueryStatement, new String[] {"tim_rsu_id"})) {
             int fieldNum = 1;
 
             for (String col : timDbTables.getTimRsuTable()) {

--- a/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
+++ b/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
@@ -8,10 +8,12 @@ import java.sql.SQLIntegrityConstraintViolationException;
 import com.trihydro.library.helpers.SQLNullHandler;
 import com.trihydro.library.tables.TimDbTables;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class TimRsuService extends BaseService {
 
     private TimDbTables timDbTables;
@@ -39,14 +41,15 @@ public class TimRsuService extends BaseService {
                 }
                 fieldNum++;
             }
-            Long timRsuId = dbInteractions.executeAndLog(preparedStatement, "tim rsu");
-            return timRsuId;
+            return dbInteractions.executeAndLog(preparedStatement, "tim rsu");
         } catch (SQLException e) {
-            // java.sql.SQLIntegrityConstraintViolationException: ORA-00001: unique constraint (CVCOMMS.TIM_RSU_U) violated 
-            if (!(e instanceof SQLIntegrityConstraintViolationException)) {
-                e.printStackTrace();
+            if (e.getMessage() != null && e.getMessage().contains("unique constraint")) {
+                // Avoid logging the common error when trying to insert a duplicate record
+                return Long.valueOf(0);
             }
 
+            // Log the exception if it's not a unique constraint violation
+            log.error("SQL Exception while adding TIM RSU: {}", e.getMessage(), e);
             return Long.valueOf(0);
         }
     }

--- a/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
+++ b/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
@@ -1,5 +1,6 @@
 package com.trihydro.loggerkafkaconsumer.app.services;
 
+import com.trihydro.library.helpers.DbInteractions;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -13,12 +14,14 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class TimRsuService extends BaseService {
+public class TimRsuService {
+    private final DbInteractions dbInteractions;
     private final TimDbTables timDbTables;
     private final SQLNullHandler sqlNullHandler;
 
     @Autowired
-    public TimRsuService(TimDbTables timDbTables, SQLNullHandler sqlNullHandler) {
+    public TimRsuService(DbInteractions dbInteractions, TimDbTables timDbTables, SQLNullHandler sqlNullHandler) {
+        this.dbInteractions = dbInteractions;
         this.timDbTables = timDbTables;
         this.sqlNullHandler = sqlNullHandler;
     }

--- a/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
+++ b/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
@@ -3,7 +3,6 @@ package com.trihydro.loggerkafkaconsumer.app.services;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.SQLIntegrityConstraintViolationException;
 
 import com.trihydro.library.helpers.SQLNullHandler;
 import com.trihydro.library.tables.TimDbTables;

--- a/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
+++ b/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
@@ -45,12 +45,12 @@ public class TimRsuService extends BaseService {
         } catch (SQLException e) {
             if (e.getMessage() != null && e.getMessage().contains("unique constraint")) {
                 // Avoid logging the common error when trying to insert a duplicate record
-                return Long.valueOf(0);
+                return 0L;
             }
 
             // Log the exception if it's not a unique constraint violation
             log.error("SQL Exception while adding TIM RSU: {}", e.getMessage(), e);
-            return Long.valueOf(0);
+            return 0L;
         }
     }
 }

--- a/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
+++ b/logger-kafka-consumer/src/main/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuService.java
@@ -24,14 +24,9 @@ public class TimRsuService extends BaseService {
     }
 
     public Long AddTimRsu(Long timId, Integer rsuId, Integer rsuIndex) {
+        String insertQueryStatement = timDbTables.buildInsertQueryStatement("tim_rsu", timDbTables.getTimRsuTable());
 
-        PreparedStatement preparedStatement = null;
-        Connection connection = null;
-
-        try {
-            connection = dbInteractions.getConnectionPool();
-            String insertQueryStatement = timDbTables.buildInsertQueryStatement("tim_rsu", timDbTables.getTimRsuTable());
-            preparedStatement = connection.prepareStatement(insertQueryStatement, new String[] {"tim_rsu_id"});
+        try(Connection connection = dbInteractions.getConnectionPool(); PreparedStatement preparedStatement = connection.prepareStatement(insertQueryStatement, new String[] {"tim_rsu_id"})) {
             int fieldNum = 1;
 
             for (String col : timDbTables.getTimRsuTable()) {
@@ -53,19 +48,6 @@ public class TimRsuService extends BaseService {
             }
 
             return Long.valueOf(0);
-        } finally {
-            try {
-                // close prepared statement
-                if (preparedStatement != null) {
-                    preparedStatement.close();
-                }
-                // return connection back to pool
-                if (connection != null) {
-                    connection.close();
-                }
-            } catch (SQLException e) {
-                e.printStackTrace();
-            }
         }
     }
 }

--- a/logger-kafka-consumer/src/test/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuServiceTest.java
+++ b/logger-kafka-consumer/src/test/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuServiceTest.java
@@ -1,44 +1,72 @@
 package com.trihydro.loggerkafkaconsumer.app.services;
 
-import java.sql.SQLException;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
-import org.mockito.Spy;
-
+import com.trihydro.library.helpers.DbInteractions;
 import com.trihydro.library.helpers.SQLNullHandler;
 import com.trihydro.library.tables.TimDbTables;
 
-public class TimRsuServiceTest extends TestBase<TimRsuService> {
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 
-    @Spy
-    private TimDbTables mockTimDbTables = new TimDbTables();
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TimRsuServiceTest {
+
+    @Mock
+    private DbInteractions mockDbInteractions;
+    @Mock
+    private TimDbTables mockTimDbTables;
     @Mock
     private SQLNullHandler mockSqlNullHandler;
+    @Mock
+    private Connection mockConnection;
+    @Mock
+    private PreparedStatement mockPreparedStatement;
+
+    private TimRsuService uut;
 
     @BeforeEach
-    public void setupSubTest() {
-        uut.InjectDependencies(mockTimDbTables, mockSqlNullHandler);
+    public void setup() throws Exception {
+        // Initialize mocks
+        mockDbInteractions = mock(DbInteractions.class);
+        mockTimDbTables = mock(TimDbTables.class);
+        mockSqlNullHandler = mock(SQLNullHandler.class);
+        mockConnection = mock(Connection.class);
+        mockPreparedStatement = mock(PreparedStatement.class);
+
+        // Stub common behaviors
+        when(mockDbInteractions.getConnectionPool()).thenReturn(mockConnection);
+        when(mockConnection.prepareStatement(anyString(), any(String[].class))).thenReturn(mockPreparedStatement);
+        when(mockTimDbTables.buildInsertQueryStatement(anyString(), anyList())).thenReturn("INSERT INTO tim_rsu ...");
+        when(mockTimDbTables.getTimRsuTable()).thenReturn(List.of("TIM_ID", "RSU_ID", "RSU_INDEX"));
+
+        // Instantiate the service with the mocked dependencies
+        uut = new TimRsuService(mockDbInteractions, mockTimDbTables, mockSqlNullHandler);
     }
 
     @Test
     public void AddTimRsu_SUCCESS() throws SQLException {
         // Arrange
-        Long timId = -1l;
+        Long timId = -1L;
         int rsuId = -2;
         int rsuIndex = 0;
+
+        when(mockDbInteractions.executeAndLog(any(PreparedStatement.class), anyString())).thenReturn(-1L);
+
         // Act
         Long data = uut.AddTimRsu(timId, rsuId, rsuIndex);
 
         // Assert
-        Assertions.assertEquals(Long.valueOf(-1), data);
-        verify(mockSqlNullHandler).setLongOrNull(mockPreparedStatement, 1, timId);// TIM_ID
-        verify(mockSqlNullHandler).setIntegerOrNull(mockPreparedStatement, 2, rsuId);// RSU_ID
-        verify(mockSqlNullHandler).setIntegerOrNull(mockPreparedStatement, 3, rsuIndex);// RSU_INDEX
+        assertEquals(Long.valueOf(-1), data);
+        verify(mockSqlNullHandler).setLongOrNull(mockPreparedStatement, 1, timId); // TIM_ID
+        verify(mockSqlNullHandler).setIntegerOrNull(mockPreparedStatement, 2, rsuId); // RSU_ID
+        verify(mockSqlNullHandler).setIntegerOrNull(mockPreparedStatement, 3, rsuIndex); // RSU_INDEX
         verify(mockPreparedStatement).close();
         verify(mockConnection).close();
     }
@@ -46,16 +74,17 @@ public class TimRsuServiceTest extends TestBase<TimRsuService> {
     @Test
     public void AddTimRsu_FAIL() throws SQLException {
         // Arrange
-        Long timId = -1l;
+        Long timId = -1L;
         int rsuId = -2;
         int rsuIndex = 0;
-        doThrow(new SQLException("UNIQUENESS CONSTRAINT VIOLATION")).when(mockSqlNullHandler).setLongOrNull(mockPreparedStatement, 1, timId);
+
+        doThrow(new SQLException("unique constraint")).when(mockSqlNullHandler).setLongOrNull(mockPreparedStatement, 1, timId);
 
         // Act
         Long data = uut.AddTimRsu(timId, rsuId, rsuIndex);
 
         // Assert
-        Assertions.assertEquals(Long.valueOf(0), data);
+        assertEquals(Long.valueOf(0), data);
         verify(mockPreparedStatement).close();
         verify(mockConnection).close();
     }

--- a/logger-kafka-consumer/src/test/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuServiceTest.java
+++ b/logger-kafka-consumer/src/test/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuServiceTest.java
@@ -72,13 +72,31 @@ public class TimRsuServiceTest {
     }
 
     @Test
-    public void AddTimRsu_FAIL() throws SQLException {
+    public void AddTimRsu_FAIL_UniqueConstraint() throws SQLException {
         // Arrange
         Long timId = -1L;
         int rsuId = -2;
         int rsuIndex = 0;
 
         doThrow(new SQLException("unique constraint")).when(mockSqlNullHandler).setLongOrNull(mockPreparedStatement, 1, timId);
+
+        // Act
+        Long data = uut.AddTimRsu(timId, rsuId, rsuIndex);
+
+        // Assert
+        assertEquals(Long.valueOf(0), data);
+        verify(mockPreparedStatement).close();
+        verify(mockConnection).close();
+    }
+
+    @Test
+    public void AddTimRsu_FAIL_OtherSQLException() throws SQLException {
+        // Arrange
+        Long timId = -1L;
+        int rsuId = -2;
+        int rsuIndex = 0;
+
+        doThrow(new SQLException("other sql exception")).when(mockSqlNullHandler).setLongOrNull(mockPreparedStatement, 1, timId);
 
         // Act
         Long data = uut.AddTimRsu(timId, rsuId, rsuIndex);

--- a/logger-kafka-consumer/src/test/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuServiceTest.java
+++ b/logger-kafka-consumer/src/test/java/com/trihydro/loggerkafkaconsumer/app/services/TimRsuServiceTest.java
@@ -57,13 +57,13 @@ public class TimRsuServiceTest {
         int rsuId = -2;
         int rsuIndex = 0;
 
-        when(mockDbInteractions.executeAndLog(any(PreparedStatement.class), anyString())).thenReturn(-1L);
+        when(mockDbInteractions.executeAndLog(any(PreparedStatement.class), anyString())).thenReturn(37L);
 
         // Act
         Long data = uut.AddTimRsu(timId, rsuId, rsuIndex);
 
         // Assert
-        assertEquals(Long.valueOf(-1), data);
+        assertEquals(Long.valueOf(37L), data);
         verify(mockSqlNullHandler).setLongOrNull(mockPreparedStatement, 1, timId); // TIM_ID
         verify(mockSqlNullHandler).setIntegerOrNull(mockPreparedStatement, 2, rsuId); // RSU_ID
         verify(mockSqlNullHandler).setIntegerOrNull(mockPreparedStatement, 3, rsuIndex); // RSU_INDEX
@@ -78,7 +78,7 @@ public class TimRsuServiceTest {
         int rsuId = -2;
         int rsuIndex = 0;
 
-        doThrow(new SQLException("unique constraint")).when(mockSqlNullHandler).setLongOrNull(mockPreparedStatement, 1, timId);
+        doThrow(new SQLException("duplicate key value violates unique constraint \"tim_rsu_rsu_id_tim_id_rsu_index_key\"")).when(mockSqlNullHandler).setLongOrNull(mockPreparedStatement, 1, timId);
 
         // Act
         Long data = uut.AddTimRsu(timId, rsuId, rsuIndex);
@@ -102,7 +102,7 @@ public class TimRsuServiceTest {
         Long data = uut.AddTimRsu(timId, rsuId, rsuIndex);
 
         // Assert
-        assertEquals(Long.valueOf(0), data);
+        assertEquals(Long.valueOf(-1), data);
         verify(mockPreparedStatement).close();
         verify(mockConnection).close();
     }


### PR DESCRIPTION
## Problem  
The `TimRsuService` class in the `logger-kafka-consumer` module was intended to suppress logging of unique constraint errors. However, these errors are still causing stack traces to be printed.  

## Solution  
The `TimRsuService` class has been modified to detect unique constraint errors by checking for the phrase "unique constraint" in the exception message, rather than relying on a specific exception type.

### Additional Changes  
- **TimRsuService** no longer extends **BaseService**, improving testability.  
- **TimRsuServiceTest** no longer extends **TestBase**, allowing the use of a constructor instead of the `InjectDependencies` method.  
- Added the `@Slf4j` annotation to **TimRsuService**.  
- Updated **TimRsuService** to use **try-with-resources** for better resource management.  
- Modified **TimRsuService** to return **0L** for duplicate keys and **-1L** for other SQL errors. This change does not impact application functionality, as callers do not use the return value.

## Testing  
- Updated unit tests to verify that a duplicate key error results in a return value of `0L`, while other SQL exceptions result in `-1L`, ensuring that unique constraint errors are handled distinctly.  
- Since the `@Slf4j` annotation is used for logging, log output verification is not included in the unit tests.  
- **Disclaimer:** Local verification of logging behavior was not performed.