### PR TITLE
Fix identical points check for negative latitude/longitude values

### DIFF
--- a/cv-data-service-library/src/main/java/com/trihydro/library/helpers/Utility.java
+++ b/cv-data-service-library/src/main/java/com/trihydro/library/helpers/Utility.java
@@ -287,17 +287,17 @@ public class Utility {
         BigDecimal secondPointLongitude =
             secondPoint.getLongitude().round(new java.math.MathContext(precision));
 
+        // Check if the first and second points are identical
+        if (firstPointLatitude.equals(secondPointLatitude) &&
+            firstPointLongitude.equals(secondPointLongitude)) {
+            throw new IdenticalPointsException();
+        }
+
         // 1) Get the difference in latitude between the first and second points.
         BigDecimal differenceInLatitude = firstPointLatitude.subtract(secondPointLatitude);
 
         // 2) Get the difference in longitude between the first and second points.
         BigDecimal differenceInLongitude = firstPointLongitude.subtract(secondPointLongitude);
-
-        // Check if the first and second points are identical
-        if (differenceInLatitude.equals(BigDecimal.ZERO) &&
-            differenceInLongitude.equals(BigDecimal.ZERO)) {
-            throw new IdenticalPointsException();
-        }
 
         // 3) Multiply the difference in latitude by the meters per surface degree to get d0Latitude.
         BigDecimal d0Latitude =

--- a/cv-data-service-library/src/main/java/com/trihydro/library/model/Milepost.java
+++ b/cv-data-service-library/src/main/java/com/trihydro/library/model/Milepost.java
@@ -16,6 +16,35 @@ public class Milepost {
     private BigDecimal longitude;
 
     public Milepost() {
+
+    }
+
+    /**
+     * Constructor to create a new Milepost object with specified attributes.
+     *
+     * @param commonName common name of the milepost
+     * @param milepost   milepost value
+     * @param direction  direction of the milepost
+     * @param latitude   latitude of the milepost
+     * @param longitude  longitude of the milepost
+     */
+    public Milepost(String commonName, Double milepost, String direction, BigDecimal latitude, BigDecimal longitude) {
+        this.commonName = commonName;
+        this.milepost = milepost;
+        this.direction = direction;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    /**
+     * Constructor to create a new Milepost object with specified latitude
+     * and longitude. Dummy values are used for the other attributes.
+     *
+     * @param latitude   latitude of the milepost
+     * @param longitude  longitude of the milepost
+     */
+    public Milepost(BigDecimal latitude, BigDecimal longitude) {
+        this("Unknown", 0.0, "Unknown", latitude, longitude);
     }
 
     /**

--- a/cv-data-service-library/src/test/java/com/trihydro/library/helpers/UtilityTest.java
+++ b/cv-data-service-library/src/test/java/com/trihydro/library/helpers/UtilityTest.java
@@ -149,12 +149,8 @@ public class UtilityTest {
         BigDecimal firstLon = BigDecimal.valueOf(-71.135100);
         BigDecimal secondLat = BigDecimal.valueOf(-29.945241);
         BigDecimal secondLon = BigDecimal.valueOf(-71.134510);
-        Milepost firstMilepost = new Milepost();
-        firstMilepost.setLatitude(firstLat);
-        firstMilepost.setLongitude(firstLon);
-        Milepost secondMilepost = new Milepost();
-        secondMilepost.setLatitude(secondLat);
-        secondMilepost.setLongitude(secondLon);
+        Milepost firstMilepost = createMilepost(firstLat, firstLon);
+        Milepost secondMilepost = createMilepost(secondLat, secondLon);
 
         // Act
         Coordinate result = uut.calculateAnchorCoordinate(firstMilepost, secondMilepost);
@@ -177,12 +173,8 @@ public class UtilityTest {
         BigDecimal firstLon = BigDecimal.valueOf(138.783680);
         BigDecimal secondLat = BigDecimal.valueOf(-34.864070);
         BigDecimal secondLon = BigDecimal.valueOf(138.779918);
-        Milepost firstMilepost = new Milepost();
-        firstMilepost.setLatitude(firstLat);
-        firstMilepost.setLongitude(firstLon);
-        Milepost secondMilepost = new Milepost();
-        secondMilepost.setLatitude(secondLat);
-        secondMilepost.setLongitude(secondLon);
+        Milepost firstMilepost = createMilepost(firstLat, firstLon);
+        Milepost secondMilepost = createMilepost(secondLat, secondLon);
 
         // Act
         Coordinate result = uut.calculateAnchorCoordinate(firstMilepost, secondMilepost);
@@ -205,12 +197,8 @@ public class UtilityTest {
         BigDecimal firstLon = BigDecimal.valueOf(139.924244);
         BigDecimal secondLat = BigDecimal.valueOf(36.874820);
         BigDecimal secondLon = BigDecimal.valueOf(139.918023);
-        Milepost firstMilepost = new Milepost();
-        firstMilepost.setLatitude(firstLat);
-        firstMilepost.setLongitude(firstLon);
-        Milepost secondMilepost = new Milepost();
-        secondMilepost.setLatitude(secondLat);
-        secondMilepost.setLongitude(secondLon);
+        Milepost firstMilepost = createMilepost(firstLat, firstLon);
+        Milepost secondMilepost = createMilepost(secondLat, secondLon);
 
         // Act
         Coordinate result = uut.calculateAnchorCoordinate(firstMilepost, secondMilepost);
@@ -233,12 +221,8 @@ public class UtilityTest {
         BigDecimal firstLon = BigDecimal.valueOf(-106.147423);
         BigDecimal secondLat = BigDecimal.valueOf(39.50418);
         BigDecimal secondLon = BigDecimal.valueOf(-106.145944);
-        Milepost firstMilepost = new Milepost();
-        firstMilepost.setLatitude(firstLat);
-        firstMilepost.setLongitude(firstLon);
-        Milepost secondMilepost = new Milepost();
-        secondMilepost.setLatitude(secondLat);
-        secondMilepost.setLongitude(secondLon);
+        Milepost firstMilepost = createMilepost(firstLat, firstLon);
+        Milepost secondMilepost = createMilepost(secondLat, secondLon);
 
         // Act
         Coordinate result = uut.calculateAnchorCoordinate(firstMilepost, secondMilepost);
@@ -258,12 +242,8 @@ public class UtilityTest {
         // Arrange
         BigDecimal lat = BigDecimal.valueOf(0);
         BigDecimal lon = BigDecimal.valueOf(0);
-        Milepost firstMilepost = new Milepost();
-        firstMilepost.setLatitude(lat);
-        firstMilepost.setLongitude(lon);
-        Milepost secondMilepost = new Milepost();
-        secondMilepost.setLatitude(lat);
-        secondMilepost.setLongitude(lon);
+        Milepost firstMilepost = createMilepost(lat, lon);
+        Milepost secondMilepost = createMilepost(lat, lon);
 
         // Act & Assert
         Assertions.assertThrows(Utility.IdenticalPointsException.class, () -> {
@@ -276,12 +256,8 @@ public class UtilityTest {
         // Arrange
         BigDecimal lat = BigDecimal.valueOf(40);
         BigDecimal lon = BigDecimal.valueOf(-100);
-        Milepost firstMilepost = new Milepost();
-        firstMilepost.setLatitude(lat);
-        firstMilepost.setLongitude(lon);
-        Milepost secondMilepost = new Milepost();
-        secondMilepost.setLatitude(lat);
-        secondMilepost.setLongitude(lon);
+        Milepost firstMilepost = createMilepost(lat, lon);
+        Milepost secondMilepost = createMilepost(lat, lon);
 
         // Act & Assert
         Assertions.assertThrows(Utility.IdenticalPointsException.class, () -> {
@@ -294,12 +270,8 @@ public class UtilityTest {
         // Arrange
         BigDecimal lat = BigDecimal.valueOf(-40);
         BigDecimal lon = BigDecimal.valueOf(100);
-        Milepost firstMilepost = new Milepost();
-        firstMilepost.setLatitude(lat);
-        firstMilepost.setLongitude(lon);
-        Milepost secondMilepost = new Milepost();
-        secondMilepost.setLatitude(lat);
-        secondMilepost.setLongitude(lon);
+        Milepost firstMilepost = createMilepost(lat, lon);
+        Milepost secondMilepost = createMilepost(lat, lon);
 
         // Act & Assert
         Assertions.assertThrows(Utility.IdenticalPointsException.class, () -> {
@@ -312,12 +284,8 @@ public class UtilityTest {
         // Arrange
         BigDecimal lat = BigDecimal.valueOf(-40);
         BigDecimal lon = BigDecimal.valueOf(100);
-        Milepost firstMilepost = new Milepost();
-        firstMilepost.setLatitude(lat);
-        firstMilepost.setLongitude(lon);
-        Milepost secondMilepost = new Milepost();
-        secondMilepost.setLatitude(lat);
-        secondMilepost.setLongitude(lon);
+        Milepost firstMilepost = createMilepost(lat, lon);
+        Milepost secondMilepost = createMilepost(lat, lon);
 
         // Act & Assert
         Assertions.assertThrows(Utility.IdenticalPointsException.class, () -> {
@@ -330,17 +298,27 @@ public class UtilityTest {
         // Arrange
         BigDecimal lat = BigDecimal.valueOf(-40);
         BigDecimal lon = BigDecimal.valueOf(-100);
-        Milepost firstMilepost = new Milepost();
-        firstMilepost.setLatitude(lat);
-        firstMilepost.setLongitude(lon);
-        Milepost secondMilepost = new Milepost();
-        secondMilepost.setLatitude(lat);
-        secondMilepost.setLongitude(lon);
+        Milepost firstMilepost = createMilepost(lat, lon);
+        Milepost secondMilepost = createMilepost(lat, lon);
 
         // Act & Assert
         Assertions.assertThrows(Utility.IdenticalPointsException.class, () -> {
             uut.calculateAnchorCoordinate(firstMilepost, secondMilepost);
         });
+    }
+
+    /**
+     * Creates a new Milepost instance and sets its latitude and longitude values.
+     *
+     * @param latitude  the latitude of the Milepost
+     * @param longitude the longitude of the Milepost
+     * @return a newly created Milepost instance with the specified latitude and longitude
+     */
+    private Milepost createMilepost(BigDecimal latitude, BigDecimal longitude) {
+        Milepost milepost = new Milepost();
+        milepost.setLatitude(latitude);
+        milepost.setLongitude(longitude);
+        return milepost;
     }
 
 }

--- a/cv-data-service-library/src/test/java/com/trihydro/library/helpers/UtilityTest.java
+++ b/cv-data-service-library/src/test/java/com/trihydro/library/helpers/UtilityTest.java
@@ -254,10 +254,82 @@ public class UtilityTest {
     }
 
     @Test
-    public void calculateAnchorCoordinate_identicalPoints() {
+    public void calculateAnchorCoordinate_identicalPoints_zero() {
         // Arrange
         BigDecimal lat = BigDecimal.valueOf(0);
         BigDecimal lon = BigDecimal.valueOf(0);
+        Milepost firstMilepost = new Milepost();
+        firstMilepost.setLatitude(lat);
+        firstMilepost.setLongitude(lon);
+        Milepost secondMilepost = new Milepost();
+        secondMilepost.setLatitude(lat);
+        secondMilepost.setLongitude(lon);
+
+        // Act & Assert
+        Assertions.assertThrows(Utility.IdenticalPointsException.class, () -> {
+            uut.calculateAnchorCoordinate(firstMilepost, secondMilepost);
+        });
+    }
+
+    @Test
+    public void calculateAnchorCoordinate_identicalPoints_positiveLat_negativeLon() {
+        // Arrange
+        BigDecimal lat = BigDecimal.valueOf(40);
+        BigDecimal lon = BigDecimal.valueOf(-100);
+        Milepost firstMilepost = new Milepost();
+        firstMilepost.setLatitude(lat);
+        firstMilepost.setLongitude(lon);
+        Milepost secondMilepost = new Milepost();
+        secondMilepost.setLatitude(lat);
+        secondMilepost.setLongitude(lon);
+
+        // Act & Assert
+        Assertions.assertThrows(Utility.IdenticalPointsException.class, () -> {
+            uut.calculateAnchorCoordinate(firstMilepost, secondMilepost);
+        });
+    }
+
+    @Test
+    public void calculateAnchorCoordinate_identicalPoints_negativeLat_positiveLon() {
+        // Arrange
+        BigDecimal lat = BigDecimal.valueOf(-40);
+        BigDecimal lon = BigDecimal.valueOf(100);
+        Milepost firstMilepost = new Milepost();
+        firstMilepost.setLatitude(lat);
+        firstMilepost.setLongitude(lon);
+        Milepost secondMilepost = new Milepost();
+        secondMilepost.setLatitude(lat);
+        secondMilepost.setLongitude(lon);
+
+        // Act & Assert
+        Assertions.assertThrows(Utility.IdenticalPointsException.class, () -> {
+            uut.calculateAnchorCoordinate(firstMilepost, secondMilepost);
+        });
+    }
+
+    @Test
+    public void calculateAnchorCoordinate_identicalPoints_positiveLat_positiveLon() {
+        // Arrange
+        BigDecimal lat = BigDecimal.valueOf(-40);
+        BigDecimal lon = BigDecimal.valueOf(100);
+        Milepost firstMilepost = new Milepost();
+        firstMilepost.setLatitude(lat);
+        firstMilepost.setLongitude(lon);
+        Milepost secondMilepost = new Milepost();
+        secondMilepost.setLatitude(lat);
+        secondMilepost.setLongitude(lon);
+
+        // Act & Assert
+        Assertions.assertThrows(Utility.IdenticalPointsException.class, () -> {
+            uut.calculateAnchorCoordinate(firstMilepost, secondMilepost);
+        });
+    }
+
+    @Test
+    public void calculateAnchorCoordinate_identicalPoints_negativeLat_negativeLon() {
+        // Arrange
+        BigDecimal lat = BigDecimal.valueOf(-40);
+        BigDecimal lon = BigDecimal.valueOf(-100);
         Milepost firstMilepost = new Milepost();
         firstMilepost.setLatitude(lat);
         firstMilepost.setLongitude(lon);

--- a/cv-data-service-library/src/test/java/com/trihydro/library/helpers/UtilityTest.java
+++ b/cv-data-service-library/src/test/java/com/trihydro/library/helpers/UtilityTest.java
@@ -149,8 +149,8 @@ public class UtilityTest {
         BigDecimal firstLon = BigDecimal.valueOf(-71.135100);
         BigDecimal secondLat = BigDecimal.valueOf(-29.945241);
         BigDecimal secondLon = BigDecimal.valueOf(-71.134510);
-        Milepost firstMilepost = createMilepost(firstLat, firstLon);
-        Milepost secondMilepost = createMilepost(secondLat, secondLon);
+        Milepost firstMilepost = new Milepost(firstLat, firstLon);
+        Milepost secondMilepost = new Milepost(secondLat, secondLon);
 
         // Act
         Coordinate result = uut.calculateAnchorCoordinate(firstMilepost, secondMilepost);
@@ -173,8 +173,8 @@ public class UtilityTest {
         BigDecimal firstLon = BigDecimal.valueOf(138.783680);
         BigDecimal secondLat = BigDecimal.valueOf(-34.864070);
         BigDecimal secondLon = BigDecimal.valueOf(138.779918);
-        Milepost firstMilepost = createMilepost(firstLat, firstLon);
-        Milepost secondMilepost = createMilepost(secondLat, secondLon);
+        Milepost firstMilepost = new Milepost(firstLat, firstLon);
+        Milepost secondMilepost = new Milepost(secondLat, secondLon);
 
         // Act
         Coordinate result = uut.calculateAnchorCoordinate(firstMilepost, secondMilepost);
@@ -197,8 +197,8 @@ public class UtilityTest {
         BigDecimal firstLon = BigDecimal.valueOf(139.924244);
         BigDecimal secondLat = BigDecimal.valueOf(36.874820);
         BigDecimal secondLon = BigDecimal.valueOf(139.918023);
-        Milepost firstMilepost = createMilepost(firstLat, firstLon);
-        Milepost secondMilepost = createMilepost(secondLat, secondLon);
+        Milepost firstMilepost = new Milepost(firstLat, firstLon);
+        Milepost secondMilepost = new Milepost(secondLat, secondLon);
 
         // Act
         Coordinate result = uut.calculateAnchorCoordinate(firstMilepost, secondMilepost);
@@ -221,8 +221,8 @@ public class UtilityTest {
         BigDecimal firstLon = BigDecimal.valueOf(-106.147423);
         BigDecimal secondLat = BigDecimal.valueOf(39.50418);
         BigDecimal secondLon = BigDecimal.valueOf(-106.145944);
-        Milepost firstMilepost = createMilepost(firstLat, firstLon);
-        Milepost secondMilepost = createMilepost(secondLat, secondLon);
+        Milepost firstMilepost = new Milepost(firstLat, firstLon);
+        Milepost secondMilepost = new Milepost(secondLat, secondLon);
 
         // Act
         Coordinate result = uut.calculateAnchorCoordinate(firstMilepost, secondMilepost);
@@ -242,8 +242,8 @@ public class UtilityTest {
         // Arrange
         BigDecimal lat = BigDecimal.valueOf(0);
         BigDecimal lon = BigDecimal.valueOf(0);
-        Milepost firstMilepost = createMilepost(lat, lon);
-        Milepost secondMilepost = createMilepost(lat, lon);
+        Milepost firstMilepost = new Milepost(lat, lon);
+        Milepost secondMilepost = new Milepost(lat, lon);
 
         // Act & Assert
         Assertions.assertThrows(Utility.IdenticalPointsException.class, () -> {
@@ -256,8 +256,8 @@ public class UtilityTest {
         // Arrange
         BigDecimal lat = BigDecimal.valueOf(40);
         BigDecimal lon = BigDecimal.valueOf(-100);
-        Milepost firstMilepost = createMilepost(lat, lon);
-        Milepost secondMilepost = createMilepost(lat, lon);
+        Milepost firstMilepost = new Milepost(lat, lon);
+        Milepost secondMilepost = new Milepost(lat, lon);
 
         // Act & Assert
         Assertions.assertThrows(Utility.IdenticalPointsException.class, () -> {
@@ -270,8 +270,8 @@ public class UtilityTest {
         // Arrange
         BigDecimal lat = BigDecimal.valueOf(-40);
         BigDecimal lon = BigDecimal.valueOf(100);
-        Milepost firstMilepost = createMilepost(lat, lon);
-        Milepost secondMilepost = createMilepost(lat, lon);
+        Milepost firstMilepost = new Milepost(lat, lon);
+        Milepost secondMilepost = new Milepost(lat, lon);
 
         // Act & Assert
         Assertions.assertThrows(Utility.IdenticalPointsException.class, () -> {
@@ -284,8 +284,8 @@ public class UtilityTest {
         // Arrange
         BigDecimal lat = BigDecimal.valueOf(-40);
         BigDecimal lon = BigDecimal.valueOf(100);
-        Milepost firstMilepost = createMilepost(lat, lon);
-        Milepost secondMilepost = createMilepost(lat, lon);
+        Milepost firstMilepost = new Milepost(lat, lon);
+        Milepost secondMilepost = new Milepost(lat, lon);
 
         // Act & Assert
         Assertions.assertThrows(Utility.IdenticalPointsException.class, () -> {
@@ -298,27 +298,13 @@ public class UtilityTest {
         // Arrange
         BigDecimal lat = BigDecimal.valueOf(-40);
         BigDecimal lon = BigDecimal.valueOf(-100);
-        Milepost firstMilepost = createMilepost(lat, lon);
-        Milepost secondMilepost = createMilepost(lat, lon);
+        Milepost firstMilepost = new Milepost(lat, lon);
+        Milepost secondMilepost = new Milepost(lat, lon);
 
         // Act & Assert
         Assertions.assertThrows(Utility.IdenticalPointsException.class, () -> {
             uut.calculateAnchorCoordinate(firstMilepost, secondMilepost);
         });
-    }
-
-    /**
-     * Creates a new Milepost instance and sets its latitude and longitude values.
-     *
-     * @param latitude  the latitude of the Milepost
-     * @param longitude the longitude of the Milepost
-     * @return a newly created Milepost instance with the specified latitude and longitude
-     */
-    private Milepost createMilepost(BigDecimal latitude, BigDecimal longitude) {
-        Milepost milepost = new Milepost();
-        milepost.setLatitude(latitude);
-        milepost.setLongitude(longitude);
-        return milepost;
     }
 
 }


### PR DESCRIPTION
## Problem
The anchor point calculation algorithm fails to correctly identify identical points when given negative latitude or longitude values. This occurs because the check relies on differences between coordinates, which does not work as expected in these cases.

## Solution
The identical points check has been updated to directly compare the latitude and longitude values of the first and second points instead of relying on their differences.

## Testing
New unit tests were added to cover cases where latitude and longitude are non-zero, ensuring the updated check functions correctly. All tests pass successfully.