### PR TITLE
Fix Message Count Increment in TimGenerationHelper

### DIFF
--- a/cv-data-service-library/src/main/java/com/trihydro/library/helpers/TimGenerationHelper.java
+++ b/cv-data-service-library/src/main/java/com/trihydro/library/helpers/TimGenerationHelper.java
@@ -823,7 +823,7 @@ public class TimGenerationHelper {
         }
         // else increment msgCnt
         else {
-            return currentCnt++;
+            return ++currentCnt;
         }
     }
 

--- a/cv-data-service-library/src/main/java/com/trihydro/library/helpers/TimGenerationHelper.java
+++ b/cv-data-service-library/src/main/java/com/trihydro/library/helpers/TimGenerationHelper.java
@@ -709,7 +709,7 @@ public class TimGenerationHelper {
 
         OdeTravelerInformationMessage tim = new OdeTravelerInformationMessage();
         tim.setDataframes(dataframes);
-        tim.setMsgCnt(getMsgCnt(aTim.getMsgCnt()));
+        tim.setMsgCnt(getNextMessageCount(aTim.getMsgCnt()));
         tim.setPacketID(aTim.getPacketId());
 
         tim.setTimeStamp(nowAsISO);
@@ -817,13 +817,14 @@ public class TimGenerationHelper {
         return exceptions;
     }
 
-    protected int getMsgCnt(int currentCnt) {
-        if (currentCnt == 127) {
+    protected int getNextMessageCount(int currentCount) {
+        if (currentCount == 127) {
+            // reset to 1
             return 1;
         }
-        // else increment msgCnt
         else {
-            return ++currentCnt;
+            // increment by 1
+            return ++currentCount;
         }
     }
 

--- a/cv-data-service-library/src/main/java/com/trihydro/library/helpers/TimGenerationHelper.java
+++ b/cv-data-service-library/src/main/java/com/trihydro/library/helpers/TimGenerationHelper.java
@@ -817,7 +817,7 @@ public class TimGenerationHelper {
         return exceptions;
     }
 
-    private int getMsgCnt(int currentCnt) {
+    protected int getMsgCnt(int currentCnt) {
         if (currentCnt == 127) {
             return 1;
         }

--- a/cv-data-service-library/src/main/java/com/trihydro/library/helpers/TimGenerationHelper.java
+++ b/cv-data-service-library/src/main/java/com/trihydro/library/helpers/TimGenerationHelper.java
@@ -819,13 +819,9 @@ public class TimGenerationHelper {
 
     protected int getNextMessageCount(int currentCount) {
         if (currentCount == 127) {
-            // reset to 1
-            return 1;
+            currentCount = 0;
         }
-        else {
-            // increment by 1
-            return ++currentCount;
-        }
+        return ++currentCount;
     }
 
     private DataFrame getDataFrame(TimUpdateModel aTim, Milepost anchor, boolean resetStartTimes,

--- a/cv-data-service-library/src/test/java/com/trihydro/library/helpers/TimGenerationHelperTest.java
+++ b/cv-data-service-library/src/test/java/com/trihydro/library/helpers/TimGenerationHelperTest.java
@@ -1308,26 +1308,26 @@ class TimGenerationHelperTest {
     }
 
     @Test
-    public void getMsgCnt_ShouldIncrementFrom2To3() {
+    public void getNextMessageCount_ShouldIncrementFrom2To3() {
         // Arrange
         int currentMsgCnt = 2;
         int expectedMsgCnt = 3;
 
         // Act
-        var msgCnt = uut.getMsgCnt(currentMsgCnt);
+        var msgCnt = uut.getNextMessageCount(currentMsgCnt);
 
         // Assert
         Assertions.assertEquals(expectedMsgCnt, msgCnt);
     }
 
     @Test
-    public void getMsgCnt_ShouldRollOverFrom127To1() {
+    public void getNextMessageCount_ShouldRollOverFrom127To1() {
         // Arrange
         int currentMsgCnt = 127;
         int expectedMsgCnt = 1;
 
         // Act
-        var msgCnt = uut.getMsgCnt(currentMsgCnt);
+        var msgCnt = uut.getNextMessageCount(currentMsgCnt);
 
         // Assert
         Assertions.assertEquals(expectedMsgCnt, msgCnt);

--- a/cv-data-service-library/src/test/java/com/trihydro/library/helpers/TimGenerationHelperTest.java
+++ b/cv-data-service-library/src/test/java/com/trihydro/library/helpers/TimGenerationHelperTest.java
@@ -1307,6 +1307,32 @@ class TimGenerationHelperTest {
         Assertions.assertFalse(success);
     }
 
+    @Test
+    public void getMsgCnt_ShouldIncrementFrom2To3() {
+        // Arrange
+        int currentMsgCnt = 2;
+        int expectedMsgCnt = 3;
+
+        // Act
+        var msgCnt = uut.getMsgCnt(currentMsgCnt);
+
+        // Assert
+        Assertions.assertEquals(expectedMsgCnt, msgCnt);
+    }
+
+    @Test
+    public void getMsgCnt_ShouldRollOverFrom127To1() {
+        // Arrange
+        int currentMsgCnt = 127;
+        int expectedMsgCnt = 1;
+
+        // Act
+        var msgCnt = uut.getMsgCnt(currentMsgCnt);
+
+        // Assert
+        Assertions.assertEquals(expectedMsgCnt, msgCnt);
+    }
+
     private void setupActiveTimModel() {
         tum = new TimUpdateModel();
         tum.setActiveTimId(activeTimId);


### PR DESCRIPTION
## Problem
When resubmitting a TIM, the TimGenerationHelper class uses msgCnt++ in a return statement to increment and return the message count. However, this approach returns the value before it is incremented, leading to an incorrect message count.

## Solution
The method in TimGenerationHelper has been updated to use ++msgCnt instead of msgCnt++. This ensures that the message count is returned with the correct incremented value.

## Testing
Unit tests have been added for the updated method to verify that the message count increments correctly and that it rolls over to 1 when the currentCount passed is 127.