### PR TITLE
bug: start and rollover msgCnt to zero not one

### DIFF
--- a/cv-data-service-library/src/main/java/com/trihydro/library/service/WydotTimService.java
+++ b/cv-data-service-library/src/main/java/com/trihydro/library/service/WydotTimService.java
@@ -624,9 +624,9 @@ public class WydotTimService {
         // set TIM packetId
         timToSend.getTim().setPacketID(tim.getPacketID());
 
-        // roll msgCnt over to 1 if at 127
+        // roll msgCnt over to 0 if at 127
         if (tim.getMsgCnt() == 127)
-            timToSend.getTim().setMsgCnt(1);
+            timToSend.getTim().setMsgCnt(0);
         // else increment msgCnt
         else
             timToSend.getTim().setMsgCnt(tim.getMsgCnt() + 1);


### PR DESCRIPTION
Made this change in accordance with this ticket description: 
https://dev.azure.com/trihydro/CV/_workitems/edit/18315

This differs from the CDOT dev branch, it is still starting `msgCnt` at 1:
https://github.com/CDOT-CV/TIM-Manager/blob/dev/cv-data-service-library/src/main/java/com/trihydro/library/service/WydotTimService.java
