### PR TITLE
Initialize TIM msgCnt as zero

### DIFF
--- a/cv-data-service-library/src/main/java/com/trihydro/library/helpers/TimGenerationHelper.java
+++ b/cv-data-service-library/src/main/java/com/trihydro/library/helpers/TimGenerationHelper.java
@@ -1131,8 +1131,8 @@ public class TimGenerationHelper {
                 createNewActiveTimHoldingRecord(timToSend.getTim().getPacketID(), aTim,
                     rsu.getRsuTarget(), nextRsuIndex, null);
 
-                // set msgCnt to 1 and create new packetId
-                timToSend.getTim().setMsgCnt(1);
+                // set msgCnt to 0 and create new packetId
+                timToSend.getTim().setMsgCnt(0);
                 timToSend.getRequest().getRsus()[0].setRsuIndex(nextRsuIndex);
 
                 var newRsuEx = odeService.sendNewTimToRsu(timToSend);

--- a/cv-data-service-library/src/main/java/com/trihydro/library/service/WydotTimService.java
+++ b/cv-data-service-library/src/main/java/com/trihydro/library/service/WydotTimService.java
@@ -357,8 +357,8 @@ public class WydotTimService {
                 var df = timToSend.getTim().getDataframes()[0];
                 timToSend.getRequest().setSnmp(snmpHelper.getSnmp(df.getStartDateTime(), endDateTime, timToSend));
 
-                // set msgCnt to 1
-                timToSend.getTim().setMsgCnt(1);
+                // set msgCnt to 0
+                timToSend.getTim().setMsgCnt(0);
                 odeService.sendNewTimToRsu(timToSend);
             }
         }
@@ -534,8 +534,8 @@ public class WydotTimService {
 
     private void sendNewTimToSdw(WydotTravelerInputData timToSend, String recordId, List<Milepost> reducedMileposts) {
 
-        // set msgCnt to 1 and create new packetId
-        timToSend.getTim().setMsgCnt(1);
+        // set msgCnt to 0 and create new packetId
+        timToSend.getTim().setMsgCnt(0);
 
         SDW sdw = new SDW();
 

--- a/cv-data-service-library/src/test/java/com/trihydro/library/helpers/TimGenerationHelperTest.java
+++ b/cv-data-service-library/src/test/java/com/trihydro/library/helpers/TimGenerationHelperTest.java
@@ -1340,7 +1340,7 @@ class TimGenerationHelperTest {
         tum.setEndPoint(new Coordinate(BigDecimal.valueOf(-3L), BigDecimal.valueOf(-4L)));
 
         // TIM Props
-        tum.setMsgCnt(1);// int
+        tum.setMsgCnt(0);// int
         tum.setUrlB("urlb");// String
         tum.setStartDate_Timestamp(Timestamp.from(Instant.now()));// Timestamp
         tum.setEndDate_Timestamp(Timestamp.from(Instant.now()));// Timestamp


### PR DESCRIPTION
In my [previous PR](https://github.com/Trihydro/TIM-Manager/pull/63) I made an update to rollover a TIM's `msgCnt` to zero, but I missed making the same change for new TIMs.

This update is for adhering to the CTW standards: https://dev.azure.com/trihydro/CV/_workitems/edit/18315